### PR TITLE
feat: bump chart versions and references automatically

### DIFF
--- a/.github/workflows/bump-chart.yaml
+++ b/.github/workflows/bump-chart.yaml
@@ -1,0 +1,27 @@
+## This job is triggered by the "Release version" of any
+## of the tracetest components. When a new version of any tracetest
+## component is released, this workflow should be triggered and
+## it will update the respective chart with the new release version
+##
+##
+## Required values in the payload:
+## * @string project_name
+## * @string version
+name: Update chart version
+
+on:
+    repository_dispatch:
+        types: [update-chart]
+
+jobs:
+    update-chart:
+        name: Update chart
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Update appVersion
+              run: |
+                ./scripts/update_chart.sh \
+                    ${{ github.event.client_payload.project_name }} \
+                    ${{ github.event.client_payload.version }}
+    

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -1,0 +1,9 @@
+commit_and_push() {
+    message=$1
+
+    git config --global user.name "GitHub Actions"
+    git config --global user.email ""
+
+    git commit -m "$message"
+    git push
+}

--- a/scripts/update_chart.sh
+++ b/scripts/update_chart.sh
@@ -20,33 +20,7 @@ source `get_path ./git.sh`
 projectName=$1
 version=$2
 
-affectedCharts=()
-
-populate_affected_charts() {
-    projectName=$1
-
-    if [[ "$projectName" == "core" ]]; then
-        affectedCharts+=("charts/tracetest-core")
-    elif [[ "$projectName" == "cloud" ]]; then
-        affectedCharts+=("charts/tracetest-cloud")
-        affectedCharts+=("charts/tracetest-agent-operator")
-        affectedCharts+=("charts/tracetest-monitor-operator")
-    elif [[ "$projectName" == "frontend" ]]; then
-        affectedCharts+=("charts/tracetest-frontend")
-    elif [[ "$projectName" == "pokeshop" ]]; then
-        affectedCharts+=("charts/pokeshop-demo")
-    fi
-}
-
-populate_affected_charts $projectName
 update_chart_references $projectName $version `get_path ./update_chart_instructions.yaml`
-
-for chart in "${affectedCharts[@]}"
-do
-    path="$chart/Chart.yaml"
-    oldVersion=`yq '.appVersion' $path`
-    sed -i "s/appVersion: $oldVersion/appVersion: $version/g" $path
-done
 
 git add `get_path ../charts`
 git status

--- a/scripts/update_chart.sh
+++ b/scripts/update_chart.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+# Update the `appVersion` in each chart affected by a new release
+# Parameters:
+# @string projectName
+# @string version
+projectName=$1
+version=$2
+
+affectedCharts=()
+
+populate_affected_charts() {
+    projectName=$1
+
+    if [[ "$projectName" == "core" ]]; then
+        affectedCharts+=("charts/tracetest-core")
+    elif [[ "$projectName" == "cloud" ]]; then
+        affectedCharts+=("charts/tracetest-cloud")
+        affectedCharts+=("charts/tracetest-agent-operator")
+        affectedCharts+=("charts/tracetest-monitor-operator")
+    elif [[ "$projectName" == "frontend" ]]; then
+        affectedCharts+=("charts/tracetest-frontend")
+    elif [[ "$projectName" == "pokeshop" ]]; then
+        affectedCharts+=("charts/pokeshop-demo")
+    fi
+}
+
+populate_affected_charts $projectName
+
+for chart in "${affectedCharts[@]}"
+do
+    path="$chart/Chart.yaml"
+    oldVersion=`yq '.appVersion' $path`
+    sed -i "s/appVersion: $oldVersion/appVersion: $version/g" $path
+done

--- a/scripts/update_chart.sh
+++ b/scripts/update_chart.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-
-
 get_path() {
     path=$1
     PWD=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
@@ -13,6 +11,7 @@ get_path() {
 }
 
 source `get_path ./update_chart_references.sh`
+source `get_path ./git.sh`
 
 # Update the `appVersion` in each chart affected by a new release
 # Parameters:
@@ -51,5 +50,5 @@ done
 
 git add `get_path ../charts`
 git status
-git commit -m "Bump chart to version $version"
-git push --force-with-lease
+
+commit_and_push "Bump chart to version $version"

--- a/scripts/update_chart.sh
+++ b/scripts/update_chart.sh
@@ -2,6 +2,18 @@
 
 set -e
 
+
+
+get_path() {
+    path=$1
+    PWD=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+    realPath="$PWD/$path"
+
+    echo $realPath
+}
+
+source `get_path ./update_chart_references.sh`
+
 # Update the `appVersion` in each chart affected by a new release
 # Parameters:
 # @string projectName
@@ -28,6 +40,7 @@ populate_affected_charts() {
 }
 
 populate_affected_charts $projectName
+update_chart_references $projectName $version `get_path ./update_chart_instructions.yaml`
 
 for chart in "${affectedCharts[@]}"
 do
@@ -35,3 +48,7 @@ do
     oldVersion=`yq '.appVersion' $path`
     sed -i "s/appVersion: $oldVersion/appVersion: $version/g" $path
 done
+
+git add `get_path ../charts`
+git commit -m "Bump chart to version $version"
+git push --force-with-lease

--- a/scripts/update_chart.sh
+++ b/scripts/update_chart.sh
@@ -50,5 +50,6 @@ do
 done
 
 git add `get_path ../charts`
+git status
 git commit -m "Bump chart to version $version"
 git push --force-with-lease

--- a/scripts/update_chart_instructions.yaml
+++ b/scripts/update_chart_instructions.yaml
@@ -1,0 +1,5 @@
+# Define what files/paths needs to be updated with new tag for each repository
+# The file paths are relative to `argo/` directory
+oss:
+- file: charts/tracetest-agent-operator/values.yaml
+  jsonpath: .config.targetVersion

--- a/scripts/update_chart_instructions.yaml
+++ b/scripts/update_chart_instructions.yaml
@@ -3,3 +3,23 @@
 oss:
 - file: charts/tracetest-agent-operator/values.yaml
   jsonpath: .config.targetVersion
+
+core:
+- file: charts/tracetest-core/Chart.yaml
+  jsonpath: .appVersion
+
+cloud:
+- file: charts/tracetest-cloud/Chart.yaml
+  jsonpath: .appVersion
+- file: charts/tracetest-agent-operator/Chart.yaml
+  jsonpath: .appVersion
+- file: charts/tracetest-monitor-operator/Chart.yaml
+  jsonpath: .appVersion
+
+frontend:
+- file: charts/tracetest-frontend/Chart.yaml
+  jsonpath: .appVersion
+
+pokeshop:
+- file: charts/pokeshop-demo/Chart.yaml
+  jsonpath: .appVersion

--- a/scripts/update_chart_references.sh
+++ b/scripts/update_chart_references.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+update_chart_references() {
+    REPO_NAME=$1
+    NEW_TAG=$2
+    INSTRUCTIONS_FILE=$3
+
+    instructions=`yq e ".${REPO_NAME}" -o=json "$INSTRUCTIONS_FILE"`
+    if [[ "$instructions" != "null" ]]; then
+        echo "$instructions" | jq -c .[] | while read -r line; do
+            FILE=$(echo $line | jq -r '.file')
+            JSON_PATH=$(echo $line | jq -r '.jsonpath')
+            SED_EXPRESSION=$(echo $line | jq -r '.sed_expression // empty')
+            ABSOLUTE_FILE_PATH=`get_path ../$FILE`
+
+            echo "$FILE:"
+            echo "  JSON path: $JSON_PATH"
+
+            if [[ -n "$SED_EXPRESSION" ]]; then
+                echo "  SED expression: " '"'$SED_EXPRESSION'"'
+                # Use yq to get the value, and then sed to update it
+                ORIGINAL_VALUE=$(yq e "$JSON_PATH" "$ABSOLUTE_FILE_PATH")
+                REPLACED_SED_EXPRESSION=$(echo "$SED_EXPRESSION" | sed "s/{{TAG}}/$NEW_TAG/g")
+                UPDATED_VALUE=$(echo "$ORIGINAL_VALUE" | sed "$REPLACED_SED_EXPRESSION")
+                yq e "$JSON_PATH = \"$UPDATED_VALUE\"" -i "$ABSOLUTE_FILE_PATH"
+            else
+                # Default handling for direct JSON paths
+                yq e "$JSON_PATH = \"$NEW_TAG\"" -i "$ABSOLUTE_FILE_PATH"
+            fi
+            echo
+        done
+    fi
+}


### PR DESCRIPTION
This PR makes the charts to be updated when another version of a component is updated. Each component has a different name `oss`, `core`, `cloud`, `frontend`, and `pokeshop`

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
