### PR TITLE
feat: use NATS cluster

### DIFF
--- a/charts/tracetest-common/templates/_functions.tpl
+++ b/charts/tracetest-common/templates/_functions.tpl
@@ -55,6 +55,6 @@ Create a URI from a given object containing protocol, hostname, port, and path.
 {{- else }}
   {{- $releaseName := .Release.Name -}}
   {{- $releaseNamespace := .Release.Namespace -}}
-  {{- printf "nats://%s-nats-headless.%s" $releaseName $releaseNamespace }}
+  {{- printf "nats://%s-nats.%s" $releaseName $releaseNamespace }}
 {{- end }}
 {{- end }}

--- a/charts/tracetest-onprem/values.yaml
+++ b/charts/tracetest-onprem/values.yaml
@@ -90,33 +90,53 @@ global:
       path: "/"
 
 nats:
+  credentials:
+    username: admin
+
   enabled: true
-  
+
+  natsBox:
+    enabled: false
+
   config:
+    cluster:
+      enabled: true
+      replicas: 3
     jetstream:
       enabled: true
       fileStore:
-        enabled: true
-        dir: /data
         pvc:
-          enabled: true
           size: 10Gi
       memoryStore:
-          enabled: true
-          maxSize: 1Gi
+        enabled: true
+        maxSize: 1Gi
+    merge:
+      accounts:
+        $SYS:
+          users:
+          - {user: << $NATS_ADMIN_USERNAME >>, password: << $NATS_ADMIN_PASSWORD >>}
 
-    natsBox:
-      container:
-        env:
-          # different from k8s units, suffix must be B, KiB, MiB, GiB, or TiB
-          # should be ~90% of memory limit
-          GOMEMLIMIT: 900MiB
-        merge:
-          # recommended limit is at least 2 CPU cores and 8Gi Memory for production JetStream clusters
-          resources:
-            requests:
-              cpu: 250m # one entire CPU
-              memory: 1Gi
-            limits:
-              memory: 1Gi
+  container:
+    merge:
+      env:
+      - name: NATS_ADMIN_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: tracetest-nats-credentials
+            key: username
+      - name: NATS_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: tracetest-nats-credentials
+            key: password
+      - name: SERVER_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+
+  podTemplate:
+    topologySpreadConstraints:
+      kubernetes.io/hostname:
+        maxSkew: 1
+        whenUnsatisfiable: ScheduleAnyway
 

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -6,3 +6,6 @@ nodes:
   - containerPort: 30000
     hostPort: 30000
     protocol: TCP
+- role: worker
+- role: worker
+- role: worker


### PR DESCRIPTION
This PR configures NATS as a cluster for HA and improved resiliency. Before we were using a single node NATS deployment. In the case of NATS pod restart for any reason (like node maintenance, for example), having a single NATS pod makes it hard for clients to keep working. With multiple pods, clients can automatically switch connections to other working NATS pod avoiding or minimizing downtime.

## Changes

- Use NATS cluster deployment

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
