### PR TITLE
feat: allow overriding resources and replicas for all core containers

### DIFF
--- a/charts/tracetest-core/templates/deployment.yaml
+++ b/charts/tracetest-core/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "tracetest-core.labels" $ | nindent 4 }}
     tracetest/component: {{ .name }}
 spec:
-  replicas: {{ .replicaCount }}
+  replicas: {{ .replicaCount | default $.Values.deploymentReplicas | default 1 }}
   selector:
     matchLabels:
       {{- include "tracetest-core.selectorLabels" $ | nindent 6 }}
@@ -115,7 +115,7 @@ spec:
               path: /
               port: http
           resources:
-            {{- toYaml .resources | nindent 12 }}
+            {{- toYaml (default $.Values.deploymentResources .resources) | nindent 12 }}
           volumeMounts:
           - name: config
             mountPath: /app/config

--- a/charts/tracetest-core/values.yaml
+++ b/charts/tracetest-core/values.yaml
@@ -2,7 +2,6 @@ global:
   licenseKey: ""
   imagePullSecret: ""
   tracetestImageRegistry: ""
-  replicasPerService: 1
 
   tracetestCore:
     service:
@@ -35,33 +34,48 @@ server:
 image:
   repository: kubeshop/tracetest-core
 
+# this value applies to all deployments, unless a deployment overrides it
+deploymentReplicas: 1
+deploymentResources: {}
 deployments:
   - name: api
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_ENABLED: false
 
   - name: worker-trigger
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_STEPS: trigger_resolver trigger_result
   - name: worker-poller
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_STEPS: poll_start poll_evaluate
   - name: worker-results
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_STEPS: linter_runner assertion_runner
   - name: worker-monitors
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_STEPS: monitor_runner monitor_alerts
   - name: worker-suites
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true


### PR DESCRIPTION
This PR adds options to the tracetest-core chart to allow defining global default replica count and resources for all the deployments. Each service can be individually overwritten too.

Example:

```yaml
# all services will have these values
deploymentReplicas: 2
deploymentResources:
  limits:
    cpu: 250m
    memory: 512Mi
  requests:
    cpu: 100m
    memory: 128Mi

deployments:
  # the api service gets these specific settings
  - name: api
    replicaCount: 4
    resources:
      limits:
        cpu: 500m
        memory: 2048Mi
      requests:
        cpu: 100m
        memory: 128Mi
```