### PR TITLE
doc: add cluster sizing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ global:
 ```
 </details>
 
+## Cluster sizing
+
+Depending on the size of your organization, your deployment might require different sizes. We provide a `small` and `large` deployment sizing examples.
+To use it you can:
+
+```
+# large cluster
+helm install my-tracetest tracetestcloud/tracetest-onprem \
+  --set global.licenseKey=YOUR-TRACETEST-LICENSE \
+  --values <your-values.yaml> \
+  --values https://raw.githubusercontent.com/kubeshop/tracetest-cloud-charts/main/values-cluster-large.yaml
+```
+
+```
+# small cluster
+helm install my-tracetest tracetestcloud/tracetest-onprem \
+  --set global.licenseKey=YOUR-TRACETEST-LICENSE \
+  --values <your-values.yaml> \
+  --values https://raw.githubusercontent.com/kubeshop/tracetest-cloud-charts/main/values-cluster-small.yaml
+```
+
 ## Questions
 
 Feel free to contact us at [our Slack](https://dub.sh/tracetest-community) if you have any questions.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ global:
 ```
 </details>
 
-## Cluster sizing
+## Cluster Sizing
 
 Depending on the size of your organization, your deployment might require different sizes. We provide a `small` and `large` deployment sizing examples.
 Use the following commands to select the size for your deployment:

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ global:
 ## Cluster sizing
 
 Depending on the size of your organization, your deployment might require different sizes. We provide a `small` and `large` deployment sizing examples.
-To use it you can:
+Use the following commands to select the size for your deployment:
 
 ```
 # large cluster

--- a/charts/tracetest-core/templates/deployment.yaml
+++ b/charts/tracetest-core/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "tracetest-core.labels" $ | nindent 4 }}
     tracetest/component: {{ .name }}
 spec:
-  replicas: {{ .replicaCount }}
+  replicas: {{ .replicaCount | default $.Values.deploymentReplicas | default 1 }}
   selector:
     matchLabels:
       {{- include "tracetest-core.selectorLabels" $ | nindent 6 }}
@@ -115,7 +115,7 @@ spec:
               path: /
               port: http
           resources:
-            {{- toYaml .resources | nindent 12 }}
+            {{- toYaml (default $.Values.deploymentResources .resources) | nindent 12 }}
           volumeMounts:
           - name: config
             mountPath: /app/config

--- a/charts/tracetest-core/values.yaml
+++ b/charts/tracetest-core/values.yaml
@@ -2,7 +2,6 @@ global:
   licenseKey: ""
   imagePullSecret: ""
   tracetestImageRegistry: ""
-  replicasPerService: 1
 
   tracetestCore:
     service:
@@ -35,33 +34,48 @@ server:
 image:
   repository: kubeshop/tracetest-core
 
+# this value applies to all deployments, unless a deployment overrides it
+deploymentReplicas: 1
+deploymentResources: {}
 deployments:
   - name: api
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_ENABLED: false
 
   - name: worker-trigger
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_STEPS: trigger_resolver trigger_result
   - name: worker-poller
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_STEPS: poll_start poll_evaluate
   - name: worker-results
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_STEPS: linter_runner assertion_runner
   - name: worker-monitors
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true
       TRACETEST_SERVER_WORKFLOW_STEPS: monitor_runner monitor_alerts
   - name: worker-suites
+    # uncomment if you want this service to override the global deploymentReplicas
+    # replicaCount: 1
     env:
       TRACETEST_SERVER_API_ENABLED: false
       TRACETEST_SERVER_WORKFLOW_ENABLED: true

--- a/values-cluster-large.yaml
+++ b/values-cluster-large.yaml
@@ -1,6 +1,7 @@
 # tracetest relies on NATS as a service bus for communication between its components.
 nats:
-  cluster:
+  config:
+    cluster:
       enabled: true
       name: "nats"
       replicas: 3
@@ -32,7 +33,8 @@ tracetest-core:
       cpu: 250m
       memory: 512Mi
 
-# tracetest-cloud handles accounts, environments and non test related data.
+# tracetest-cloud handles accounts, environments and non test related data, but more importantly
+# it serves as the control plane for the agents, so it is better to have it highly available.
 tracetest-cloud:
   deployment:
     replicas: 3

--- a/values-cluster-large.yaml
+++ b/values-cluster-large.yaml
@@ -1,0 +1,109 @@
+# tracetest relies on NATS as a service bus for communication between its components.
+nats:
+  cluster:
+      enabled: true
+      name: "nats"
+      replicas: 3
+
+# tracetest-frontend is a simple frontend service that serves the UI.
+# it is a static web app serving service, so the load is minimal.
+tracetest-frontend:
+  replicaCount: 2
+  resources: 
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+# tracetest-core handles most of the API requests and test workloads.
+# It is composed of 6 services. Each of those can be individually configured with replicas and limits,
+# but in general they all require the same resources.
+tracetest-core:
+  # deploymentReplicas defines the replica count for each service if not overridden in the deployments section.
+  deploymentReplicas: 2
+  # deploymentResources defines the default resources for each service if not overridden in the deployments section.
+  deploymentResources:
+    limits:
+      cpu: 500m
+      memory: 2048Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi
+
+# tracetest-cloud handles accounts, environments and non test related data.
+tracetest-cloud:
+  deployment:
+    replicas: 3
+    resources:
+      limits:
+        cpu: 500m
+        memory: 2048Mi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+
+# tracetest-agent-operator is the service in charge of launching and stoppin serverless agents.
+# This service is very lightway, and in general doesn't require multiple replicas.
+tracetest-agent-operator:
+  deployment:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+# tracetest-monitor-operator is the service in charge of scheduling synthetic monitoring tasks.
+# This service is very lightway, and in general doesn't require multiple replicas.
+tracetest-monitor-operator:
+  deployment:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+# tracetest-auth is a collection of services that handle authentication and authorization.
+tracetest-auth:
+  # keto manages authorization
+  keto:
+    replicaCount: 1
+    deployment:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 2048Mi
+        requests:
+          cpu: 250m
+          memory: 512Mi
+  
+  # kratos handles authentication and SSO
+  kratos:
+    replicaCount: 1
+    deployment:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 2048Mi
+        requests:
+          cpu: 250m
+          memory: 512Mi
+
+  # oathkeeper is a reverse proxy that handles authentication and authorization
+  oathkeeper:
+    replicaCount: 1
+    deployment:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 2048Mi
+        requests:
+          cpu: 250m
+          memory: 512Mi

--- a/values-cluster-small.yaml
+++ b/values-cluster-small.yaml
@@ -1,0 +1,108 @@
+# tracetest relies on NATS as a service bus for communication between its components.
+# for a production workload we recommend using a cluster nats for HA
+nats:
+  cluster:
+    enabled: false
+
+# tracetest-frontend is a simple frontend service that serves the UI.
+# it is a static web app serving service, so the load is minimal.
+tracetest-frontend:
+  replicaCount: 1
+  resources: 
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+# tracetest-core handles most of the API requests and test workloads.
+# It is composed of 6 services. Each of those can be individually configured with replicas and limits,
+# but in general they all require the same resources.
+tracetest-core:
+  # deploymentReplicas defines the replica count for each service if not overridden in the deployments section.
+  deploymentReplicas: 1
+  # deploymentResources defines the default resources for each service if not overridden in the deployments section.
+  deploymentResources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+# tracetest-cloud handles accounts, environments and non test related data.
+tracetest-cloud:
+  deployment:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+# tracetest-agent-operator is the service in charge of launching and stoppin serverless agents.
+# This service is very lightway, and in general doesn't require multiple replicas.
+tracetest-agent-operator:
+  deployment:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+# tracetest-monitor-operator is the service in charge of scheduling synthetic monitoring tasks.
+# This service is very lightway, and in general doesn't require multiple replicas.
+tracetest-monitor-operator:
+  deployment:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+# tracetest-auth is a collection of services that handle authentication and authorization.
+tracetest-auth:
+  # keto manages authorization
+  keto:
+    replicaCount: 1
+    deployment:
+      resources:
+        limits:
+          cpu: 250m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+  
+  # kratos handles authentication and SSO
+  kratos:
+    replicaCount: 1
+    deployment:
+      resources:
+        limits:
+          cpu: 250m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+
+  # oathkeeper is a reverse proxy that handles authentication and authorization
+  oathkeeper:
+    replicaCount: 1
+    deployment:
+      resources:
+        limits:
+          cpu: 250m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi

--- a/values-cluster-small.yaml
+++ b/values-cluster-small.yaml
@@ -1,8 +1,11 @@
 # tracetest relies on NATS as a service bus for communication between its components.
 # for a production workload we recommend using a cluster nats for HA
+# tracetest relies on NATS as a service bus for communication between its components.
 nats:
-  cluster:
-    enabled: false
+  config:
+    cluster:
+      enabled: false
+      replicas: 1
 
 # tracetest-frontend is a simple frontend service that serves the UI.
 # it is a static web app serving service, so the load is minimal.
@@ -31,7 +34,8 @@ tracetest-core:
       cpu: 100m
       memory: 128Mi
 
-# tracetest-cloud handles accounts, environments and non test related data.
+# tracetest-cloud handles accounts, environments and non test related data, but more importantly
+# it serves as the control plane for the agents, so it is better to have it highly available.
 tracetest-cloud:
   deployment:
     replicas: 1


### PR DESCRIPTION
This PR adds example value files with proposals on how to size onprem clusters

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
