### PR TITLE
chore: Update pokeshop chart to provide easy installation

### DIFF
--- a/charts/pokeshop-demo/Chart.yaml
+++ b/charts/pokeshop-demo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v1.1.0
+version: v1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pokeshop-demo/templates/_helpers.tpl
+++ b/charts/pokeshop-demo/templates/_helpers.tpl
@@ -71,11 +71,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Common labels (Worker)
+Common labels (Queue Worker)
 */}}
-{{- define "pokeshop-demo.worker.labels" -}}
+{{- define "pokeshop-demo.queueworker.labels" -}}
 helm.sh/chart: {{ include "pokeshop-demo.chart" . }}
-{{ include "pokeshop-demo.worker.selectorLabels" . }}
+{{ include "pokeshop-demo.queueworker.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -83,9 +83,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels (Worker)
+Selector labels (Queue Worker)
 */}}
-{{- define "pokeshop-demo.worker.selectorLabels" -}}
+{{- define "pokeshop-demo.queueworker.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "pokeshop-demo.name" . }}-worker
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/pokeshop-demo/templates/deployment.api.yaml
+++ b/charts/pokeshop-demo/templates/deployment.api.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "pokeshop-demo.api.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.pokeshop.replicaCount }}
+  replicas: {{ .Values.pokeshop.api.replicaCount }}
   selector:
     matchLabels:
       {{- include "pokeshop-demo.api.selectorLabels" . | nindent 6 }}
@@ -23,7 +23,7 @@ spec:
               containerPort: 80
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources | nindent 12 }}
+            {{- toYaml .Values.pokeshop.api.resources | nindent 12 }}
           env:
             - name: NPM_RUN_COMMAND
               value: api
@@ -39,7 +39,7 @@ spec:
               containerPort: {{ .Values.pokeshop.service.rpcPort }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources.api | nindent 12 }}
+            {{- toYaml .Values.pokeshop.api.resources | nindent 12 }}
           env:
             - name: NPM_RUN_COMMAND
               value: rpc

--- a/charts/pokeshop-demo/templates/deployment.api.yaml
+++ b/charts/pokeshop-demo/templates/deployment.api.yaml
@@ -39,7 +39,7 @@ spec:
               containerPort: {{ .Values.pokeshop.service.rpcPort }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources | nindent 12 }}
+            {{- toYaml .Values.pokeshop.resources.api | nindent 12 }}
           env:
             - name: NPM_RUN_COMMAND
               value: rpc

--- a/charts/pokeshop-demo/templates/deployment.queueworker.yaml
+++ b/charts/pokeshop-demo/templates/deployment.queueworker.yaml
@@ -23,7 +23,7 @@ spec:
               containerPort: 80
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources | nindent 12 }}
+            {{- toYaml .Values.pokeshop.resources.queueworker | nindent 12 }}
           env:
             - name: NPM_RUN_COMMAND
               value: worker

--- a/charts/pokeshop-demo/templates/deployment.queueworker.yaml
+++ b/charts/pokeshop-demo/templates/deployment.queueworker.yaml
@@ -3,16 +3,16 @@ kind: Deployment
 metadata:
   name: {{ include "pokeshop-demo.fullname" . }}-queueworker
   labels:
-    {{- include "pokeshop-demo.worker.labels" . | nindent 4 }}
+    {{- include "pokeshop-demo.queueworker.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.pokeshop.replicaCount }}
+  replicas: {{ .Values.pokeshop.queueworker.replicaCount }}
   selector:
     matchLabels:
-      {{- include "pokeshop-demo.worker.selectorLabels" . | nindent 6 }}
+      {{- include "pokeshop-demo.queueworker.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "pokeshop-demo.worker.selectorLabels" . | nindent 8 }}
+        {{- include "pokeshop-demo.queueworker.selectorLabels" . | nindent 8 }}
     spec:
       containers:
         - name: pokeshop-worker
@@ -23,7 +23,7 @@ spec:
               containerPort: 80
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources.queueworker | nindent 12 }}
+            {{- toYaml .Values.pokeshop.queueworker.resources | nindent 12 }}
           env:
             - name: NPM_RUN_COMMAND
               value: worker

--- a/charts/pokeshop-demo/templates/deployment.stream.yaml
+++ b/charts/pokeshop-demo/templates/deployment.stream.yaml
@@ -26,7 +26,7 @@ spec:
               name: controller
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources | nindent 12 }}
+            {{- toYaml .Values.pokeshop.resources.stream | nindent 12 }}
           env:
             - name: KAFKA_ADVERTISED_LISTENERS
               value: PLAINTEXT://stream.{{ .Release.Namespace }}:9092

--- a/charts/pokeshop-demo/templates/deployment.stream.yaml
+++ b/charts/pokeshop-demo/templates/deployment.stream.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "pokeshop-demo.stream.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.pokeshop.replicaCount }}
+  replicas: {{ .Values.pokeshop.stream.replicaCount }}
   selector:
     matchLabels:
       {{- include "pokeshop-demo.stream.selectorLabels" . | nindent 6 }}
@@ -26,7 +26,7 @@ spec:
               name: controller
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources.stream | nindent 12 }}
+            {{- toYaml .Values.pokeshop.stream.resources | nindent 12 }}
           env:
             - name: KAFKA_ADVERTISED_LISTENERS
               value: PLAINTEXT://stream.{{ .Release.Namespace }}:9092

--- a/charts/pokeshop-demo/templates/deployment.streamworker.yaml
+++ b/charts/pokeshop-demo/templates/deployment.streamworker.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "pokeshop-demo.fullname" . }}-queueworker
+  name: {{ include "pokeshop-demo.fullname" . }}-streamworker
   labels:
     {{- include "pokeshop-demo.streamworker.labels" . | nindent 4 }}
 spec:

--- a/charts/pokeshop-demo/templates/deployment.streamworker.yaml
+++ b/charts/pokeshop-demo/templates/deployment.streamworker.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pokeshop-demo.fullname" . }}-queueworker
+  labels:
+    {{- include "pokeshop-demo.streamworker.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.pokeshop.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "pokeshop-demo.streamworker.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pokeshop-demo.streamworker.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: pokeshop-stream-worker
+          image: "{{ .Values.pokeshop.image.repository }}:{{ .Values.pokeshop.image.tag }}"
+          imagePullPolicy: {{ .Values.pokeshop.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.pokeshop.resources | nindent 12 }}
+          env:
+            - name: NPM_RUN_COMMAND
+              value: pokeshop-stream-worker
+            - name: SERVICE_NAME
+              value: pokeshop-stream-worker
+            {{- toYaml .Values.pokeshop.env | nindent 12 }}

--- a/charts/pokeshop-demo/templates/deployment.streamworker.yaml
+++ b/charts/pokeshop-demo/templates/deployment.streamworker.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "pokeshop-demo.streamworker.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.pokeshop.replicaCount }}
+  replicas: {{ .Values.pokeshop.streamworker.replicaCount }}
   selector:
     matchLabels:
       {{- include "pokeshop-demo.streamworker.selectorLabels" . | nindent 6 }}
@@ -23,7 +23,7 @@ spec:
               containerPort: 80
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources.streamworker | nindent 12 }}
+            {{- toYaml .Values.pokeshop.streamworker.resources | nindent 12 }}
           env:
             - name: NPM_RUN_COMMAND
               value: pokeshop-stream-worker

--- a/charts/pokeshop-demo/templates/deployment.streamworker.yaml
+++ b/charts/pokeshop-demo/templates/deployment.streamworker.yaml
@@ -23,7 +23,7 @@ spec:
               containerPort: 80
               protocol: TCP
           resources:
-            {{- toYaml .Values.pokeshop.resources | nindent 12 }}
+            {{- toYaml .Values.pokeshop.resources.streamworker | nindent 12 }}
           env:
             - name: NPM_RUN_COMMAND
               value: pokeshop-stream-worker

--- a/charts/pokeshop-demo/templates/deployment.streamworker.yaml
+++ b/charts/pokeshop-demo/templates/deployment.streamworker.yaml
@@ -29,4 +29,8 @@ spec:
               value: stream-worker
             - name: SERVICE_NAME
               value: pokeshop-stream-worker
+            - name: KAFKA_BROKER
+              value: stream:9092
+            - name: KAFKA_TOPIC
+              value: pokeshop
             {{- toYaml .Values.pokeshop.env | nindent 12 }}

--- a/charts/pokeshop-demo/templates/deployment.streamworker.yaml
+++ b/charts/pokeshop-demo/templates/deployment.streamworker.yaml
@@ -26,7 +26,7 @@ spec:
             {{- toYaml .Values.pokeshop.streamworker.resources | nindent 12 }}
           env:
             - name: NPM_RUN_COMMAND
-              value: pokeshop-stream-worker
+              value: stream-worker
             - name: SERVICE_NAME
               value: pokeshop-stream-worker
             {{- toYaml .Values.pokeshop.env | nindent 12 }}

--- a/charts/pokeshop-demo/templates/ingressroute.api.yaml
+++ b/charts/pokeshop-demo/templates/ingressroute.api.yaml
@@ -9,7 +9,7 @@ spec:
     - websecure
   routes:
   - kind: Rule
-    match: Host(`{{ .Values.hostname }}`)
+    match: Host(`{{ .Values.pokeshop.ingress.hostname }}`)
     services:
     - kind: Service
       name: {{ include "pokeshop-demo.fullname" . }}-api

--- a/charts/pokeshop-demo/templates/ingressroute.api.yaml
+++ b/charts/pokeshop-demo/templates/ingressroute.api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.pokeshop.ingress.enabled -}}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -25,7 +25,7 @@ spec:
     - websecure
   routes:
   - kind: Rule
-    match: Host(`{{ .Values.hostname }}`) && Headers(`Content-Type`, `application/grpc`)
+    match: Host(`{{ .Values.pokeshop.ingress.hostname }}`) && Headers(`Content-Type`, `application/grpc`)
     services:
     - kind: Service
       name: {{ include "pokeshop-demo.fullname" . }}-api

--- a/charts/pokeshop-demo/templates/ingressroute.api.yaml
+++ b/charts/pokeshop-demo/templates/ingressroute.api.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -31,3 +32,4 @@ spec:
       passHostHeader: true
       port: grpc
       scheme: h2c
+{{- end }}

--- a/charts/pokeshop-demo/templates/ingressroute.collector.yaml
+++ b/charts/pokeshop-demo/templates/ingressroute.collector.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.pokeshop.ingress.enabled -}}
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -8,7 +8,7 @@ spec:
     - websecure
   routes:
   - kind: Rule
-    match: Host(`{{ .Values.hostname }}`) && PathPrefix(`/v1/traces`)
+    match: Host(`{{ .Values.pokeshop.ingress.hostname }}`) && PathPrefix(`/v1/traces`)
     services:
     - kind: Service
       name: {{ .Release.Name }}-opentelemetry-collector

--- a/charts/pokeshop-demo/templates/ingressroute.collector.yaml
+++ b/charts/pokeshop-demo/templates/ingressroute.collector.yaml
@@ -1,13 +1,4 @@
-# ---
-# apiVersion: traefik.io/v1alpha1
-# kind: Middleware
-# metadata:
-#   name: {{ include "pokeshop-demo.fullname" . }}-otel-collector-stripprefix
-# spec:
-#   stripPrefix:
-#     prefixes:
-#       - /otc
-# ---
+{{- if .Values.ingress.enabled -}}
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -23,5 +14,4 @@ spec:
       name: {{ .Release.Name }}-opentelemetry-collector
       passHostHeader: true
       port: otlp-http
-      # middlewares:
-      # - name: {{ include "pokeshop-demo.fullname" . }}-otel-collector-stripprefix
+{{- end }}

--- a/charts/pokeshop-demo/values.yaml
+++ b/charts/pokeshop-demo/values.yaml
@@ -14,7 +14,13 @@ pokeshop:
   replicaCount: 1
 
   ingress:
-    enabled: true
+    enabled: false
+
+  resources:
+    api: {}
+    queueworker: {}
+    stream: {}
+    streamworker: {}
 
   env:
     - name: COLLECTOR_ENDPOINT

--- a/charts/pokeshop-demo/values.yaml
+++ b/charts/pokeshop-demo/values.yaml
@@ -1,4 +1,5 @@
 hostname: pokeshop.localdev
+allowedCorsOrigins: &allowedCorsOrigins https://*.tracetest.io 
 
 pokeshop:
   image:
@@ -16,11 +17,18 @@ pokeshop:
   ingress:
     enabled: false
 
-  resources:
-    api: {}
-    queueworker: {}
-    stream: {}
-    streamworker: {}
+  api:
+    resources: {}
+    replicaCount: 1
+  queueworker:
+    resources: {}
+    replicaCount: 1
+  stream:
+    resources: {}
+    replicaCount: 1
+  streamworker:
+    resources: {}
+    replicaCount: 1
 
   env:
     - name: COLLECTOR_ENDPOINT
@@ -104,7 +112,7 @@ opentelemetry-collector:
           http:
             cors:
               allowed_origins:
-                - "https://*.tracetest.io"
+                - *allowedCorsOrigins
 
     processors:
       batch:

--- a/charts/pokeshop-demo/values.yaml
+++ b/charts/pokeshop-demo/values.yaml
@@ -9,6 +9,9 @@ pokeshop:
     port: 80
     rpcPort: 8082
 
+  # This chart requires Traefik to be installed on the cluster. If you don't have Traefik installed
+  # and don't want to install it, make sure to set `ingress.enabled` as `false`. Otherwise, the installation
+  # will fail.
   ingress:
     enabled: false
     hostname: pokeshop.localdev

--- a/charts/pokeshop-demo/values.yaml
+++ b/charts/pokeshop-demo/values.yaml
@@ -9,8 +9,6 @@ pokeshop:
     port: 80
     rpcPort: 8082
 
-  replicaCount: 1
-
   ingress:
     enabled: false
     hostname: pokeshop.localdev

--- a/charts/pokeshop-demo/values.yaml
+++ b/charts/pokeshop-demo/values.yaml
@@ -13,6 +13,9 @@ pokeshop:
 
   replicaCount: 1
 
+  ingress:
+    enabled: true
+
   env:
     - name: COLLECTOR_ENDPOINT
       value: http://ttdemo-opentelemetry-collector:44317
@@ -64,7 +67,6 @@ opentelemetry-collector:
 
   image:
     repository: "otel/opentelemetry-collector-contrib"
-
 
   ports:
     otlp:

--- a/charts/pokeshop-demo/values.yaml
+++ b/charts/pokeshop-demo/values.yaml
@@ -1,6 +1,3 @@
-hostname: pokeshop.localdev
-allowedCorsOrigins: &allowedCorsOrigins https://*.tracetest.io 
-
 pokeshop:
   image:
     repository: kubeshop/demo-pokemon-api
@@ -16,6 +13,7 @@ pokeshop:
 
   ingress:
     enabled: false
+    hostname: pokeshop.localdev
 
   api:
     resources: {}
@@ -112,7 +110,7 @@ opentelemetry-collector:
           http:
             cors:
               allowed_origins:
-                - *allowedCorsOrigins
+                - "*"
 
     processors:
       batch:

--- a/scripts/setup_demo_on_kind_cluster.sh
+++ b/scripts/setup_demo_on_kind_cluster.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+export KUBECONFIG=$KUBECONFIG:$(pwd)/tracetest.kubeconfig
+kubectl config use-context kind-tracetest
+
+PROJECT_ROOT=$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")
+
+printf "\n\e[42m\e[1mInstalling Pokeshop demo\e[0m\e[0m\n"
+helm upgrade --install ttdemo -n demo --create-namespace $PROJECT_ROOT/charts/pokeshop-demo -f $PROJECT_ROOT/values-kind-demo.yaml
+
+printf "\n\e[42m\e[1mConfiguring CoreDNS\e[0m\e[0m\n"
+hosts=(tracetest.localdev)
+hosts+=(pokeshop.localdev)
+
+$PROJECT_ROOT/scripts/coredns_config.sh ttdeps-traefik.default.svc.cluster.local "${hosts[@]}"
+printf "\n"

--- a/values-kind-demo.yaml
+++ b/values-kind-demo.yaml
@@ -1,3 +1,7 @@
+pokeshop:
+  ingress:
+    enabled: true
+
 opentelemetry-collector:
   config:
     receivers:


### PR DESCRIPTION
This PR updates the Pokeshop chart to allow users to install it without needing to install Pokeshop

## Changes

- Update Pokeshop chart

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
