### PR TITLE
feat: add clenaup job to delete old entries in pokemon table

### DIFF
--- a/charts/pokeshop-demo/templates/cronjob.cleanup.yaml
+++ b/charts/pokeshop-demo/templates/cronjob.cleanup.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.pokeshop.cleanup.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "pokeshop-demo.fullname" . }}-cleanup
+  labels:
+    {{- include "pokeshop-demo.api.labels" . | nindent 4 }}
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: pg-cleanup
+              image: jbergknoff/postgresql-client
+              imagePullPolicy: IfNotPresent
+              command: 
+              - psql
+              args:
+              - "-d"
+              - "$(DATABASE_URL)"
+              - -c
+              - delete from pokemon where "createdAt" < current_timestamp - interval '1 day'
+              env:
+                {{- toYaml .Values.pokeshop.env | nindent 16 }}
+          restartPolicy: OnFailure
+{{- end -}}

--- a/charts/pokeshop-demo/values.yaml
+++ b/charts/pokeshop-demo/values.yaml
@@ -16,6 +16,9 @@ pokeshop:
     enabled: false
     hostname: pokeshop.localdev
 
+  cleanup:
+    enabled: false
+
   api:
     resources: {}
     replicaCount: 1
@@ -33,7 +36,7 @@ pokeshop:
     - name: COLLECTOR_ENDPOINT
       value: http://ttdemo-opentelemetry-collector:44317
     - name: DATABASE_URL
-      value: postgresql://ashketchum:squirtle123@postgresql:5432/pokeshop?schema=public
+      value: postgresql://ashketchum:squirtle123@postgresql:5432/pokeshop
     - name: REDIS_URL
       value: redis-headless
     - name: RABBITMQ_HOST


### PR DESCRIPTION
This PR creates an optional cronjob that deletes old entries in the pokemon table.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
