### PR TITLE
chore(public-endpoint): adding collector for public endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,4 @@ onprem/cluster: ## create onprem cluster
 .PHONY: onprem/k9s
 onprem/k9s: ## run k9s on onprem cluster locally installed
 	@sh ./scripts/start_k9s.sh
+	

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: help
+help: Makefile ## show list of commands
+	@echo "Choose a command run:"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+.PHONY: onprem/template
+onprem/template: ## generate k8s manifests of onprem and output to stdout
+	@helm template tracetest-onprem ./charts/tracetest-onprem
+
+.PHONY: onprem/build-deps
+onprem/build-deps: ## build helm dependencies for onprem charts
+	@sh ./scripts/update_chart_deps.sh
+
+.PHONY: onprem/delete-cluster
+onprem/delete-cluster: ## delete current onprem cluster
+	@kind delete cluster --name tracetest
+
+.PHONY: onprem/private-cluster
+onprem/private-cluster: ## create onprem private cluster
+	@sh ./scripts/setup_kind_cluster.sh --reset --private
+
+.PHONY: onprem/k9s
+onprem/k9s: ## run k9s on onprem cluster locally installed
+	@sh ./scripts/start_k9s.sh

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ onprem/delete-cluster: ## delete current onprem cluster
 
 .PHONY: onprem/private-cluster
 onprem/private-cluster: ## create onprem private cluster
-	@sh ./scripts/setup_kind_cluster.sh --reset --private
+	@sh ./scripts/setup_kind_cluster.sh --reset --private --build-deps
+
+.PHONY: onprem/cluster
+onprem/cluster: ## create onprem cluster
+	@sh ./scripts/setup_kind_cluster.sh --reset --build-deps
 
 .PHONY: onprem/k9s
 onprem/k9s: ## run k9s on onprem cluster locally installed

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ onprem/delete-cluster: ## delete current onprem cluster
 
 .PHONY: onprem/private-cluster
 onprem/private-cluster: ## create onprem private cluster
-	@sh ./scripts/setup_kind_cluster.sh --reset --private --build-deps
+	@sh ./scripts/setup_kind_cluster.sh --ci --private --install-demo --reset --build-deps
 
 .PHONY: onprem/cluster
 onprem/cluster: ## create onprem cluster
-	@sh ./scripts/setup_kind_cluster.sh --reset --build-deps
+	@sh ./scripts/setup_kind_cluster.sh --ci --install-demo --reset --build-deps
 
 .PHONY: onprem/k9s
 onprem/k9s: ## run k9s on onprem cluster locally installed

--- a/charts/tracetest-onprem/Chart.yaml
+++ b/charts/tracetest-onprem/Chart.yaml
@@ -24,6 +24,10 @@ dependencies:
   version: v1.14.0
   repository: file://../tracetest-monitor-operator
   condition: tracetest-monitor-operator.enabled
+- name: tracetest-public-endpoint
+  version: v1.0.0
+  repository: file://../tracetest-public-endpoint
+  condition: tracetest-public-endpoint.enabled
 - name: tracetest-auth
   version: v1.34.0
   repository: file://../tracetest-auth

--- a/charts/tracetest-onprem/requirements.yaml
+++ b/charts/tracetest-onprem/requirements.yaml
@@ -19,6 +19,10 @@ dependencies:
     version: v1.14.0
     repository: file://../tracetest-monitor-operator
     condition: tracetest-monitor-operator.enabled
+  - name: tracetest-public-endpoint
+    version: v1.0.0
+    repository: file://../tracetest-public-endpoint
+    condition: tracetest-public-endpoint.enabled
   - name: tracetest-auth
     version: v1.34.0
     repository: file://../tracetest-auth

--- a/charts/tracetest-onprem/values.yaml
+++ b/charts/tracetest-onprem/values.yaml
@@ -156,6 +156,9 @@ tracetest-agent-operator:
 tracetest-monitor-operator:
   enabled: true
 
+tracetest-public-endpoint:
+  enabled: true
+
 tracetest-auth:
   enabled: true
 

--- a/charts/tracetest-onprem/values.yaml
+++ b/charts/tracetest-onprem/values.yaml
@@ -89,6 +89,12 @@ global:
       port: *port
       path: "/"
 
+    otlpingest:
+      protocol: *protocol
+      hostname: *rootDomain
+      port: *port
+      path: "/"
+
 nats:
   credentials:
     username: admin

--- a/charts/tracetest-public-endpoint/.helmignore
+++ b/charts/tracetest-public-endpoint/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/tracetest-public-endpoint/Chart.yaml
+++ b/charts/tracetest-public-endpoint/Chart.yaml
@@ -31,4 +31,3 @@ maintainers:
   url: https://tracetest.io
 
 icon: https://cdn.prod.website-files.com/625f135a8e554e44ad158913/625f1d8ab2348b3c4e3fa870_logo.svg
-home: https://github.com/kubeshop/tracetest-cloud-charts

--- a/charts/tracetest-public-endpoint/Chart.yaml
+++ b/charts/tracetest-public-endpoint/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: tracetest-public-endpoint
+description: A Helm chart for Tracetest Public OTLP Endpoint
+home: https://github.com/kubeshop/tracetest-cloud-charts
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: v1.0.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: v1.0.0
+
+dependencies:
+- name: opentelemetry-collector
+  version: "0.105.1"
+  repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
+
+maintainers:
+- name: tracetest
+  url: https://tracetest.io
+
+icon: https://cdn.prod.website-files.com/625f135a8e554e44ad158913/625f1d8ab2348b3c4e3fa870_logo.svg
+home: https://github.com/kubeshop/tracetest-cloud-charts

--- a/charts/tracetest-public-endpoint/templates/_helpers.tpl
+++ b/charts/tracetest-public-endpoint/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tracetest-public-endpoint.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tracetest-public-endpoint.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tracetest-public-endpoint.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tracetest-public-endpoint.labels" -}}
+helm.sh/chart: {{ include "tracetest-public-endpoint.chart" . }}
+{{ include "tracetest-public-endpoint.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tracetest-public-endpoint.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tracetest-public-endpoint.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/tracetest-public-endpoint/templates/ingressroute.yaml
+++ b/charts/tracetest-public-endpoint/templates/ingressroute.yaml
@@ -1,0 +1,24 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "tracetest-public-endpoint.fullname" . }}-ingressroute
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - kind: Rule
+    match: Host(`{{ .Values.global.urls.api.hostname }}`) && PathPrefix(`/otlp`) && Headers(`Content-Type`, `application/grpc`)
+    services:
+    - kind: Service
+      name: {{ .Release.Name }}-public-endpoint-otel-collector
+      passHostHeader: true
+      port: otlp
+      scheme: h2c
+  - kind: Rule
+    match: Host(`{{ .Values.global.urls.api.hostname }}`) && PathPrefix(`/otlp`)
+    services:
+    - kind: Service
+      name: {{ .Release.Name }}-public-endpoint-otel-collector
+      passHostHeader: true
+      port: otlp-http
+      scheme: h2c

--- a/charts/tracetest-public-endpoint/templates/ingressroute.yaml
+++ b/charts/tracetest-public-endpoint/templates/ingressroute.yaml
@@ -15,10 +15,9 @@ spec:
       port: otlp
       scheme: h2c
   - kind: Rule
-    match: Host(`{{ .Values.global.urls.otlpingest.hostname }}`)
+    match: Host(`{{ .Values.global.urls.otlpingest.hostname }}`) && PathPrefix(`/v1/traces`)
     services:
     - kind: Service
       name: {{ .Release.Name }}-public-endpoint-otel-collector
       passHostHeader: true
       port: otlp-http
-      scheme: h2c

--- a/charts/tracetest-public-endpoint/templates/ingressroute.yaml
+++ b/charts/tracetest-public-endpoint/templates/ingressroute.yaml
@@ -7,7 +7,7 @@ spec:
     - websecure
   routes:
   - kind: Rule
-    match: Host(`{{ .Values.global.urls.api.hostname }}`) && PathPrefix(`/otlp`) && Headers(`Content-Type`, `application/grpc`)
+    match: Host(`{{ .Values.global.urls.otlpingest.hostname }}`) && PathPrefix(`/opentelemetry.proto.collector.trace.v1.TraceService/Export`)
     services:
     - kind: Service
       name: {{ .Release.Name }}-public-endpoint-otel-collector
@@ -15,7 +15,7 @@ spec:
       port: otlp
       scheme: h2c
   - kind: Rule
-    match: Host(`{{ .Values.global.urls.api.hostname }}`) && PathPrefix(`/otlp`)
+    match: Host(`{{ .Values.global.urls.otlpingest.hostname }}`)
     services:
     - kind: Service
       name: {{ .Release.Name }}-public-endpoint-otel-collector

--- a/charts/tracetest-public-endpoint/values.yaml
+++ b/charts/tracetest-public-endpoint/values.yaml
@@ -1,3 +1,17 @@
+global:
+  # URLs section with addresses used by clients to connect to the Tracetest OnPrem instance
+  urls:
+    protocol: &protocol "https"
+    port: &port "30000"
+    rootDomain: &rootDomain "tracetest.localdev"
+    cookieDomain: *rootDomain
+    
+    otlpingest:
+      protocol: *protocol
+      hostname: *rootDomain
+      port: *port
+      path: "/"
+
 opentelemetry-collector:
   nameOverride: public-endpoint-otel-collector
 

--- a/charts/tracetest-public-endpoint/values.yaml
+++ b/charts/tracetest-public-endpoint/values.yaml
@@ -20,8 +20,6 @@ opentelemetry-collector:
       enabled: false
     zipkin:
       enabled: false
-    metrics:
-      enabled: false
 
   config:
     receivers:

--- a/charts/tracetest-public-endpoint/values.yaml
+++ b/charts/tracetest-public-endpoint/values.yaml
@@ -1,0 +1,54 @@
+opentelemetry-collector:
+  nameOverride: public-endpoint-otel-collector
+
+  mode: deployment
+
+  image:
+    repository: "otel/opentelemetry-collector-contrib"
+    tag: "0.111.0"
+
+  ports:
+    otlp:
+      enabled: true
+    otlp-http:
+      enabled: true
+    jaeger-compact:
+      enabled: false
+    jaeger-thrift:
+      enabled: false
+    jaeger-grpc:
+      enabled: false
+    zipkin:
+      enabled: false
+    metrics:
+      enabled: false
+
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            max_recv_msg_size_mib: 20 # 10 MiB
+          http:
+            max_request_body_size: 40971520
+
+    processors:
+      batch/traces:
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+        timeout: 500ms
+
+    exporters:
+      debug:
+        verbosity: detailed
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch/traces]
+          exporters: [debug]
+
+        metrics: {}
+
+        logs: {}

--- a/charts/tracetest-public-endpoint/values.yaml
+++ b/charts/tracetest-public-endpoint/values.yaml
@@ -20,6 +20,8 @@ opentelemetry-collector:
       enabled: false
     zipkin:
       enabled: false
+    metrics:
+      enabled: false
 
   config:
     receivers:
@@ -47,6 +49,6 @@ opentelemetry-collector:
           processors: [batch/traces]
           exporters: [debug]
 
-        metrics: {}
+        metrics: null
 
-        logs: {}
+        logs: null

--- a/charts/tracetest-public-endpoint/values.yaml
+++ b/charts/tracetest-public-endpoint/values.yaml
@@ -33,7 +33,7 @@ opentelemetry-collector:
             max_request_body_size: 40971520
 
     processors:
-      batch/traces:
+      batch:
         send_batch_size: 1024
         send_batch_max_size: 2048
         timeout: 500ms
@@ -46,9 +46,18 @@ opentelemetry-collector:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [batch/traces]
+          processors: [batch]
           exporters: [debug]
 
-        metrics: null
+        # TODO: due to an issue on Helm (https://github.com/open-telemetry/opentelemetry-helm-charts/issues/223#issuecomment-1697239843)
+        # we are not able to disable metrics and logs pipeline when OTel Collector is a subchart
+        # so we are defining them as simple as possible
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
 
-        logs: null
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]

--- a/scripts/setup_kind_cluster.sh
+++ b/scripts/setup_kind_cluster.sh
@@ -15,6 +15,8 @@ function show_help() {
   echo ""
   echo "Environment variables that might be read:"
   echo "  TRACETEST_LICENSE    OnPrem license key (if not provided, the script will prompt for it)"
+  echo "  GITHUB_USERNAME      Github user name used o fetch private images (if not provided, the script will prompt for it)"
+  echo "  GITHUB_DOCKER_PAT    Github Private Access Token used o fetch private images (if not provided, the script will prompt for it)"
 }
 
 if [[ "$@" == *"--help"* ]]; then
@@ -39,13 +41,16 @@ printf "\n\e[42m\e[1mStarting cluster setup...\e[0m\e[0m\n"
 
 if [[ "$@" == *"--build-deps"* ]]; then
   printf "\n\e[42m\e[1mBuilding dependencies for tracetest-dependencies\e[0m\e[0m\n"
+  rm -rf "$PROJECT_ROOT/charts/tracetest-dependencies/charts/*"
   helm dependency update "$PROJECT_ROOT/charts/tracetest-dependencies"
 
   printf "\n\e[42m\e[1mBuilding dependencies for tracetest-onprem\e[0m\e[0m\n"
+  rm -rf "$PROJECT_ROOT/charts/tracetest-onprem/charts/*"
   helm dependency update "$PROJECT_ROOT/charts/tracetest-onprem"
 
   if [[ "$@" == *"--install-demo"* ]]; then
     printf "\n\e[42m\e[1mBuilding dependencies for pokeshop-demo\e[0m\e[0m\n"
+    rm -rf "$PROJECT_ROOT/charts/pokeshop-demo/charts/*"
     helm dependency update $PROJECT_ROOT/charts/pokeshop-demo
   fi
 fi
@@ -79,6 +84,9 @@ if [[ "$SETUP_CLUSTER" == true ]]; then
 
     for chart_dir in $PROJECT_ROOT/charts/*; do
       printf "\n\e[42m\e[1mBuilding dependencies for $(basename "$chart_dir")\e[0m\e[0m\n"
+      if [[ -d "$chart_dir/charts" ]]; then
+        rm -rf "$chart_dir/charts/*"
+      fi
       helm dependency update "$chart_dir"
     done
 

--- a/scripts/update_chart_deps.sh
+++ b/scripts/update_chart_deps.sh
@@ -1,14 +1,19 @@
-echo "Add helm repositories"
-echo ""
+time {
+    echo "Add helm repositories"
+    echo ""
 
-helm repo add traefik https://traefik.github.io/charts --force-update
-helm repo add ory https://k8s.ory.sh/helm/charts --force-update
-helm repo add jetstack https://charts.jetstack.io --force-update
-helm repo add nats https://nats-io.github.io/k8s/helm/charts/ --force-update
+    helm repo add traefik https://traefik.github.io/charts --force-update
+    helm repo add ory https://k8s.ory.sh/helm/charts --force-update
+    helm repo add jetstack https://charts.jetstack.io --force-update
+    helm repo add nats https://nats-io.github.io/k8s/helm/charts/ --force-update
 
-PROJECT_ROOT=$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")
+    PROJECT_ROOT=$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")
 
-for chart_dir in $PROJECT_ROOT/charts/*; do
-    printf "\n\e[42m\e[1mBuilding dependencies for $(basename "$chart_dir")\e[0m\e[0m\n"
-    helm dependency update "$chart_dir"
-done
+    for chart_dir in $PROJECT_ROOT/charts/*; do
+        printf "\n\e[42m\e[1mClear dependencies for $(basename "$chart_dir")\e[0m\e[0m\n"
+        rm  "$chart_dir/charts/*"
+
+        printf "\n\e[42m\e[1mBuilding dependencies for $(basename "$chart_dir")\e[0m\e[0m\n"
+        helm dependency update "$chart_dir"
+    done
+}


### PR DESCRIPTION
This PR adds a public otel collector to Tracetest, allowing users to send trace data directly to it to start making tests.

## How to test it

```sh
# create a local kind cluster
export GITHUB_USERNAME=...
export GITHUB_DOCKER_PAT=...
make onprem/private-cluster
```

After finishing to setup it, run [otel-cli](https://github.com/equinix-labs/otel-cli):

```sh
export OTEL_EXPORTER_OTLP_ENDPOINT=tracetest.localdev:30000
export OTEL_EXPORTER_OTLP_INSECURE=false
export OTEL_CLI_FAIL=true
export OTEL_CLI_VERBOSE=true
export OTEL_CLI_TLS_NO_VERIFY=true
otel-cli exec --service my-service --name "curl google" curl https://google.com
```



